### PR TITLE
Added Flush within WriteLines loop

### DIFF
--- a/io.go
+++ b/io.go
@@ -45,6 +45,9 @@ func WriteLines(writer io.Writer) Filter {
 				return err
 			}
 			arg.Out <- s
+			if err := b.Flush(); err != nil {
+				return err
+			}
 		}
 		return b.Flush()
 	})

--- a/io.go
+++ b/io.go
@@ -36,20 +36,13 @@ func Cat(filenames ...string) Filter {
 // for debugging.
 func WriteLines(writer io.Writer) Filter {
 	return FilterFunc(func(arg Arg) error {
-		b := bufio.NewWriter(writer)
 		for s := range arg.In {
-			if _, err := b.Write([]byte(s)); err != nil {
-				return err
-			}
-			if err := b.WriteByte('\n'); err != nil {
+			if _, err := writer.Write(append([]byte(s),'\n')); err != nil {
 				return err
 			}
 			arg.Out <- s
-			if err := b.Flush(); err != nil {
-				return err
-			}
 		}
-		return b.Flush()
+		return nil
 	})
 }
 


### PR DESCRIPTION
bufio buffers data before writing it. This deals data's visibility to user.
If bufio writer flushed within WriteLines loop, it will make data visible instantly.
This change will impact WriteLines performance.
Since WriteLines is geared towards debugging, it might not impact overall usability.

Fixes #1 